### PR TITLE
feat: add loading state and contact selection logic in Chat component

### DIFF
--- a/src/components/common/loading-button.tsx
+++ b/src/components/common/loading-button.tsx
@@ -57,4 +57,4 @@ const LoadingButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
 );
 LoadingButton.displayName = 'LoadingButton';
 
-export { buttonVariants,LoadingButton };
+export { buttonVariants, LoadingButton };

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -30,4 +30,4 @@ function AvatarFallback({ className, ...props }: React.ComponentProps<typeof Ava
   );
 }
 
-export { Avatar, AvatarFallback,AvatarImage };
+export { Avatar, AvatarFallback, AvatarImage };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -53,4 +53,4 @@ function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-export { Card, CardAction, CardContent,CardDescription, CardFooter, CardHeader, CardTitle };
+export { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle };

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -211,4 +211,4 @@ function CarouselNext({
   );
 }
 
-export { Carousel, type CarouselApi, CarouselContent, CarouselItem, CarouselNext,CarouselPrevious };
+export { Carousel, type CarouselApi, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious };

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -12,4 +12,4 @@ function CollapsibleContent({ ...props }: React.ComponentProps<typeof Collapsibl
   return <CollapsiblePrimitive.CollapsibleContent data-slot='collapsible-content' {...props} />;
 }
 
-export { Collapsible, CollapsibleContent,CollapsibleTrigger };
+export { Collapsible, CollapsibleContent, CollapsibleTrigger };

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -134,4 +134,4 @@ function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
   );
 }
 
-export { Form, FormControl, FormDescription, FormField,FormItem, FormLabel, FormMessage, useFormField };
+export { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage, useFormField };

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -38,4 +38,4 @@ function PopoverAnchor({ ...props }: React.ComponentProps<typeof PopoverPrimitiv
   return <PopoverPrimitive.Anchor data-slot='popover-anchor' {...props} />;
 }
 
-export { Popover, PopoverAnchor,PopoverContent, PopoverTrigger };
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger };

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -99,4 +99,4 @@ function SheetDescription({ className, ...props }: React.ComponentProps<typeof S
   );
 }
 
-export { Sheet, SheetClose, SheetContent, SheetDescription,SheetFooter, SheetHeader, SheetTitle, SheetTrigger };
+export { Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle, SheetTrigger };

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -7,7 +7,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { useIsMobile } from '@/hooks/use-mobile';
 import { cn } from '@/lib/utils';
 
-import { cva,VariantProps } from 'class-variance-authority';
+import { cva, VariantProps } from 'class-variance-authority';
 import { PanelLeftIcon } from 'lucide-react';
 import * as React from 'react';
 

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -46,4 +46,4 @@ function TooltipContent({
   );
 }
 
-export { Tooltip, TooltipContent, TooltipProvider,TooltipTrigger };
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/src/config/menu.ts
+++ b/src/config/menu.ts
@@ -1,4 +1,4 @@
-import { Home, LucideIcon, MessageCircle,UserRound } from 'lucide-react';
+import { Home, LucideIcon, MessageCircle, UserRound } from 'lucide-react';
 
 type MenuItemType = {
   title: string;

--- a/src/hooks/useGetSingleProfile.ts
+++ b/src/hooks/useGetSingleProfile.ts
@@ -1,15 +1,15 @@
-import { config } from "@/config/app";
-import { GET_SKILLS_QUERY_KEY, getSkills } from "@/services/skill.service";
-import { GET_SINGLE_USER, getUserByUID } from "@/services/user.service";
-import { Skill } from "@/types/skill.type";
-import { User } from "@/types/user.type";
+import { config } from '@/config/app';
+import { GET_SKILLS_QUERY_KEY, getSkills } from '@/services/skill.service';
+import { GET_SINGLE_USER, getUserByUID } from '@/services/user.service';
+import { Skill } from '@/types/skill.type';
+import { User } from '@/types/user.type';
 
-import { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 
-import useAuth from "./useAuth";
+import useAuth from './useAuth';
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery } from '@tanstack/react-query';
 
 const useGetSingleProfile = () => {
   const { user } = useAuth();
@@ -50,7 +50,12 @@ const useGetSingleProfile = () => {
   }, [skills]);
 
   useEffect(() => {
-    if (currentUser && Array.isArray(currentUser.learn) && Array.isArray(currentUser.teach) && skillsList.length !== 0) {
+    if (
+      currentUser &&
+      Array.isArray(currentUser.learn) &&
+      Array.isArray(currentUser.teach) &&
+      skillsList.length !== 0
+    ) {
       const learningSkills = currentUser.learn
         .map((id: string) => skillsList.filter((skill: Skill) => skill.id === id))
         .flat();
@@ -67,7 +72,7 @@ const useGetSingleProfile = () => {
     currentUser,
     learn,
     teach,
-    handleEditProfile
+    handleEditProfile,
   };
 };
 

--- a/src/pages/Chat/chat.tsx
+++ b/src/pages/Chat/chat.tsx
@@ -40,6 +40,7 @@ export default function Chat() {
 
   const [contacts, setContacts] = useState<Contact[]>([]);
   const [selectedContact, setSelectedContact] = useState<Contact | null>(null);
+  const [initialHandled, setInitialHandled] = useState(false);
   const [messagesByContact, setMessagesByContact] = useState<Record<string, Message[]>>({});
   const [loading, setLoading] = useState(true);
   const [inputValue, setInputValue] = useState('');
@@ -137,19 +138,22 @@ export default function Chat() {
 
   // ---------- 2) nếu có contactId từ location thì ưu tiên select trước ----------
   useEffect(() => {
-    if (initialContactId && contacts.length > 0) {
+    // chỉ chạy khi có contacts và chưa xử lý lần nào
+    if (contacts.length === 0 || initialHandled) return;
+
+    if (initialContactId) {
       const found = contacts.find((c) => c.id === initialContactId);
       if (found) {
         setSelectedContact(found);
-        return;
+      }
+    } else {
+      const isMobile = window.matchMedia('(max-width: 767px)').matches;
+      if (!isMobile) {
+        setSelectedContact(contacts[0]);
       }
     }
-    // nếu không có contactId thì chọn contact đầu tiên trong danh sách
-    const isMobile = window.matchMedia('(max-width: 767px)').matches;
-    if (!isMobile && !initialContactId && !selectedContact && contacts.length > 0) {
-      setSelectedContact(contacts[0]);
-    }
-  }, [contacts, selectedContact, initialContactId]);
+    setInitialHandled(true);
+  }, [contacts, initialContactId, initialHandled]);
 
   // ---------- 3) Scroll xuống cuối khi có message mới ----------
   useEffect(() => {

--- a/src/pages/Chat/chat.tsx
+++ b/src/pages/Chat/chat.tsx
@@ -16,6 +16,7 @@ import {
   where,
 } from 'firebase/firestore';
 import { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import { DesktopChatView } from './components/desktopChatView';
 import { MobileChatView } from './components/mobileChatView';
@@ -34,9 +35,13 @@ function formatTimestamp(ts: Timestamp): string {
 
 export default function Chat() {
   const { user } = useAuth();
+  const location = useLocation();
+  const initialContactId = (location.state as any)?.contactId as string | undefined;
+
   const [contacts, setContacts] = useState<Contact[]>([]);
   const [selectedContact, setSelectedContact] = useState<Contact | null>(null);
   const [messagesByContact, setMessagesByContact] = useState<Record<string, Message[]>>({});
+  const [loading, setLoading] = useState(true);
   const [inputValue, setInputValue] = useState('');
   const messageEndRef = useRef<HTMLDivElement>(null!);
   const inputRef = useRef<HTMLInputElement>(null!);
@@ -44,6 +49,8 @@ export default function Chat() {
   // ---------- 1) Ensure chat rooms exist & then subscribe realtime ----------
   useEffect(() => {
     if (!user?.id) return;
+    setLoading(true);
+
     (async () => {
       // 1.a) Lấy danh sách connections
       const userSnap = await getDoc(doc(db, 'users', user.id));
@@ -75,7 +82,8 @@ export default function Chat() {
           const data = docSnap.data();
           const parts = data.participants as string[];
           const otherId = parts.find((id) => id !== user.id);
-          if (!otherId) return;
+          // nếu otherId không nằm trong connections thì bỏ qua
+          if (!otherId || !connections.includes(otherId)) return;
 
           const raw = (data.messages as any[]) || [];
           msgsMap[otherId] = raw.map((m) => ({
@@ -90,7 +98,7 @@ export default function Chat() {
 
         setMessagesByContact(msgsMap);
 
-        // 1.d) Sau khi có msgsMap và ids…
+        // 1.d) Sau khi có msgsMap và ids
         const contactsWithTs: Array<{ contact: Contact; millis: number }> = await Promise.all(
           Array.from(ids).map(async (contactId) => {
             const uSnap = await getDoc(doc(db, 'users', contactId));
@@ -117,20 +125,31 @@ export default function Chat() {
         contactsWithTs.sort((a, b) => b.millis - a.millis);
 
         // 1.f) Cập nhật state chỉ với contact đã sort
-        setContacts(contactsWithTs.map((x) => x.contact));
+        const sorted = contactsWithTs.map((x) => x.contact);
+        setContacts(sorted);
+
+        setLoading(false);
       });
 
       return () => unsub();
     })().catch(console.error);
   }, [user]);
 
-  // ---------- 2) Trên desktop auto chọn contact đầu tiên ----------
+  // ---------- 2) nếu có contactId từ location thì ưu tiên select trước ----------
   useEffect(() => {
+    if (initialContactId && contacts.length > 0) {
+      const found = contacts.find((c) => c.id === initialContactId);
+      if (found) {
+        setSelectedContact(found);
+        return;
+      }
+    }
+    // nếu không có contactId thì chọn contact đầu tiên trong danh sách
     const isMobile = window.matchMedia('(max-width: 767px)').matches;
-    if (!isMobile && !selectedContact && contacts.length > 0) {
+    if (!isMobile && !initialContactId && !selectedContact && contacts.length > 0) {
       setSelectedContact(contacts[0]);
     }
-  }, [contacts, selectedContact]);
+  }, [contacts, selectedContact, initialContactId]);
 
   // ---------- 3) Scroll xuống cuối khi có message mới ----------
   useEffect(() => {
@@ -187,6 +206,14 @@ export default function Chat() {
   }, [selectedContact]);
 
   // ---------- 5) Render cả Mobile & Desktop ----------
+  if (loading) {
+    return (
+      <div className='flex items-center justify-center h-[calc(100vh-64px)] w-full'>
+        <div className='animate-spin rounded-full h-8 w-8 border-t-2 border-gray-400' />
+        <span className='ml-2 text-gray-600'>Đang tải cuộc trò chuyện…</span>
+      </div>
+    );
+  }
   return (
     <div className='flex flex-col h-[calc(100vh-64px)] w-full p-4 gap-4'>
       <MobileChatView

--- a/src/pages/Chat/components/contactList.tsx
+++ b/src/pages/Chat/components/contactList.tsx
@@ -3,8 +3,17 @@ import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 
 import { Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
 
 import type { Contact } from './types';
+
+// Utility to remove diacritics for accent-insensitive search
+function normalizeText(text: string) {
+  return text
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase();
+}
 
 export function ContactList({
   contacts,
@@ -15,16 +24,29 @@ export function ContactList({
   selectedId?: string;
   onSelect: (contact: Contact) => void;
 }) {
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const filteredContacts = useMemo(() => {
+    const normalizedTerm = normalizeText(searchTerm.trim());
+    if (!normalizedTerm) return contacts;
+    return contacts.filter((contact) => normalizeText(contact.name).includes(normalizedTerm));
+  }, [contacts, searchTerm]);
+
   return (
     <div className='w-full md:w-80 bg-background flex-shrink-0 rounded-lg md:border-2 md:border-primary'>
       <div className='p-4'>
         <div className='relative'>
           <Search className='absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground' />
-          <Input placeholder='Search connection' className='pl-9 bg-muted/50' />
+          <Input
+            placeholder='Search connection'
+            className='pl-9 bg-muted/50'
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+          />
         </div>
       </div>
       <div className='overflow-auto flex-1'>
-        {contacts.map((contact) => (
+        {filteredContacts.map((contact) => (
           <div
             key={contact.id}
             className={cn(

--- a/src/pages/Chat/components/types.ts
+++ b/src/pages/Chat/components/types.ts
@@ -1,4 +1,4 @@
-import { Timestamp } from 'firebase/firestore'
+import { Timestamp } from 'firebase/firestore';
 
 export interface Contact {
   id: string;
@@ -13,6 +13,6 @@ export interface Message {
   id: string;
   content: string;
   sender: 'user' | 'contact';
-  timestamp: Timestamp
+  timestamp: Timestamp;
   senderId: string;
 }

--- a/src/pages/MyNetwork/components/detail-card.tsx
+++ b/src/pages/MyNetwork/components/detail-card.tsx
@@ -21,12 +21,14 @@ import { asString, asStringArray } from '@/utils/userHelpers';
 import { arrayRemove } from 'firebase/firestore';
 import { UserRoundX } from 'lucide-react';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import '../index.css';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 const DetailCard = ({ user }: { user: User }) => {
+  const navigate = useNavigate();
   const matchPercentage = 100;
   const [open, setOpen] = useState(false);
   const { user: currentUser } = useAuth();
@@ -141,6 +143,7 @@ const DetailCard = ({ user }: { user: User }) => {
               <Button
                 variant='outline'
                 className='rounded-md px-6 md:px-10 text-sm md:text-base border-primary text-primary'
+                onClick={() => navigate('/chat', { state: { contactId: user.id } })}
               >
                 Message
               </Button>

--- a/src/pages/NotVerifyEmail/not-verify-email.tsx
+++ b/src/pages/NotVerifyEmail/not-verify-email.tsx
@@ -7,7 +7,7 @@ import handleFirebaseError from '@/utils/handlerFirebaseError';
 
 import { sendEmailVerification } from 'firebase/auth';
 import { Mail } from 'lucide-react';
-import { useCallback, useEffect,useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Link, Navigate } from 'react-router-dom';
 import { toast } from 'sonner';
 

--- a/src/pages/Profile/profile.tsx
+++ b/src/pages/Profile/profile.tsx
@@ -53,19 +53,20 @@ const Profile = () => {
               </CardHeader>
               <CardContent>
                 <ul className='space-y-2'>
-                  {Array.isArray(currentUser?.connections) && currentUser?.connections.map((connection, index) => (
-                    <li key={index} className="flex items-center gap-2">
-                      <Avatar className="h-6 w-6">
-                        <AvatarFallback className="text-xs">
-                          {connection
-                            .split(" ")
-                            .map((name) => name[0])
-                            .join("")}
-                        </AvatarFallback>
-                      </Avatar>
-                      <span className="text-sm">{connection}</span>
-                    </li>
-                  ))}
+                  {Array.isArray(currentUser?.connections) &&
+                    currentUser?.connections.map((connection, index) => (
+                      <li key={index} className='flex items-center gap-2'>
+                        <Avatar className='h-6 w-6'>
+                          <AvatarFallback className='text-xs'>
+                            {connection
+                              .split(' ')
+                              .map((name) => name[0])
+                              .join('')}
+                          </AvatarFallback>
+                        </Avatar>
+                        <span className='text-sm'>{connection}</span>
+                      </li>
+                    ))}
                 </ul>
               </CardContent>
             </Card>


### PR DESCRIPTION
What’s Changed

- DetailCard “Message” button now routes to /chat with contactId in location.state.
- Chat page reads contactId on load and opens the chat with that user.
- Falls back to selecting the first contact only if no contactId is provided.

How to Test

- In Network page, click “Message” on user A → Chat opens with A selected.
- Click “Message” on user B → Chat opens with B selected.
- Navigate to /chat directly → first contact is selected.
- On mobile view, only the contact list is shown.