### PR TITLE
fix: connect logic - add connect user in modal

### DIFF
--- a/src/components/common/alert-dialog.tsx
+++ b/src/components/common/alert-dialog.tsx
@@ -1,0 +1,37 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../ui/alert-dialog';
+
+interface AlertDialogProps {
+  open: boolean;
+  onCancle: () => void;
+  onConfirm: () => void;
+  confirmStatus: string;
+}
+
+const WithdrawAlertDialog: React.FC<AlertDialogProps> = ({ open, onCancle, onConfirm, confirmStatus }) => {
+  return (
+    <AlertDialog open={open}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Withdraw invitation</AlertDialogTitle>
+          <AlertDialogDescription>Are you sure you want to withdraw the invitation?</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancle}>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm} disabled={confirmStatus === 'pending'}>
+            Withdraw
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+export default WithdrawAlertDialog;

--- a/src/components/common/preview-card.tsx
+++ b/src/components/common/preview-card.tsx
@@ -14,6 +14,8 @@ interface PreviewCardProps {
   photoUrl?: string;
   button: ReactNode;
   className?: string;
+  setListPendingUsers?: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;
+  listPendingUsers?: Record<string, boolean>;
 }
 
 export default function PreviewCard({
@@ -25,6 +27,8 @@ export default function PreviewCard({
   photoUrl,
   button,
   className = '',
+  setListPendingUsers,
+  listPendingUsers,
 }: PreviewCardProps) {
   const [showProfileModal, setShowProfileModal] = useState(false);
 
@@ -93,7 +97,15 @@ export default function PreviewCard({
         </CardContent>
         <CardFooter>{button}</CardFooter>
       </Card>
-      {showProfileModal && <ProfileModal open={showProfileModal} onOpenChange={handleCloseProfileModal} userId={id} />}
+      {showProfileModal && (
+        <ProfileModal
+          open={showProfileModal}
+          onOpenChange={handleCloseProfileModal}
+          userId={id}
+          listPendingUsers={listPendingUsers}
+          setListPendingUsers={setListPendingUsers}
+        />
+      )}
     </>
   );
 }

--- a/src/pages/Home/components/previewCardList.tsx
+++ b/src/pages/Home/components/previewCardList.tsx
@@ -1,14 +1,5 @@
+import WithdrawAlertDialog from '@/components/common/alert-dialog';
 import PreviewCard from '@/components/common/preview-card';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { useAuth } from '@/hooks';
 import { updateUser } from '@/services/user.service';
 import { UserWithPercent } from '@/types/user.type';
@@ -26,12 +17,22 @@ interface PreviewCardListProps {
 
 const PreviewCardList = ({ results }: PreviewCardListProps) => {
   const { user: currentUser } = useAuth();
+  if (!currentUser) return;
 
   const [clickUser, setClickUser] = useState<string | null>(null);
-  const [listPendingUsers, setListPendingUsers] = useState<Record<string, boolean>>({});
+  const [listPendingUsers, setListPendingUsers] = useState<Record<string, boolean>>(
+    Array.isArray(currentUser.sentConnections)
+      ? currentUser.sentConnections.reduce(
+          (acc, id) => {
+            acc[id] = true;
+            return acc;
+          },
+          {} as Record<string, boolean>,
+        )
+      : {},
+  );
   const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
 
-  if (!currentUser) return;
   const { mutate: withdrawMutate, status: withdrawStatus } = useMutation({
     mutationFn: ({ receiverUid }: { receiverUid: string }) => {
       return Promise.all([
@@ -67,6 +68,8 @@ const PreviewCardList = ({ results }: PreviewCardListProps) => {
             teach={Array.isArray(result.teach) ? result.teach : []}
             learn={Array.isArray(result.teach) ? result.teach : []}
             photoUrl={result.photoURL}
+            setListPendingUsers={setListPendingUsers}
+            listPendingUsers={listPendingUsers}
             button={
               <CustomButtonConnect
                 className='w-[100%]'
@@ -81,20 +84,12 @@ const PreviewCardList = ({ results }: PreviewCardListProps) => {
           />
         ))}
       </div>
-      <AlertDialog open={isOpenModal}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Withdraw invitation</AlertDialogTitle>
-            <AlertDialogDescription>Are you sure you want to withdraw the invitation?</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={() => setIsOpenModal(false)}>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleWithdraw} disabled={withdrawStatus === 'pending'}>
-              Withdraw
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <WithdrawAlertDialog
+        open={isOpenModal}
+        onCancle={() => setIsOpenModal(false)}
+        onConfirm={handleWithdraw}
+        confirmStatus={withdrawStatus}
+      />
     </div>
   );
 };


### PR DESCRIPTION
- Change the connect logic: 
Previous: Getting a users' list in homepage needs to get only users who are not connected and NOT SENT request.
Now: Getting a users' list in homepage needs to get only users who are not connected.

<img width="973" alt="Screenshot 2025-05-02 at 17 30 47" src="https://github.com/user-attachments/assets/a2cc8cd6-2699-471e-b82f-3299d9a55111" />

- Add connect and  withdraw logic in modal.