### PR TITLE
fix: show connections in profile modal

### DIFF
--- a/src/components/common/profile-modal.tsx
+++ b/src/components/common/profile-modal.tsx
@@ -1,9 +1,8 @@
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { config } from '@/config/app';
 import { useAuth } from '@/hooks';
-import useGetUsers from '@/hooks/useGetUsers';
 import { getSkills } from '@/services/skill.service';
-import { getUserByUID, updateUser } from '@/services/user.service';
+import { getAllUsers, getUserByUID, updateUser } from '@/services/user.service';
 import { Skill } from '@/types/skill.type';
 import { mapConnectionInformation, mapSkillInformation } from '@/utils/mapUserInformation';
 
@@ -35,10 +34,14 @@ const ProfileModal = ({ open, onOpenChange, userId, setListPendingUsers, listPen
 
   const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
   const navigate = useNavigate();
-  const { users } = useGetUsers();
   const { user: currentUser } = useAuth();
 
   if (!currentUser) return;
+
+  const { data: users } = useQuery({
+    queryKey: ['users'],
+    queryFn: getAllUsers,
+  });
 
   const { data: user } = useQuery({
     queryKey: ['user', userId],

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -81,3 +81,8 @@ export const getUserBySkills = async (skills: string[]) => {
     ...(docSnap.data() as Omit<User, 'id'>),
   }));
 };
+
+export const getAllUsers = async () => {
+  const { data: users } = await getDocuments(config.collections.users);
+  return users as User[];
+};


### PR DESCRIPTION
- Before (not show people who are in connections with currentUser --> due to the use of useGetUsers which are only suitable in Homepage): 
<img width="1440" alt="Screenshot 2025-05-03 at 23 49 12" src="https://github.com/user-attachments/assets/0f208f8a-b0ae-40bf-a4ef-3196da3276fa" />

- After (call getAllUsers separately):
<img width="1440" alt="Screenshot 2025-05-03 at 23 51 38" src="https://github.com/user-attachments/assets/21349c6c-4676-4106-aafb-be297459da2c" />
